### PR TITLE
Fix MongoDB env variable name

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Easily create and share memorable links to any webpage with bly.li! Simply input
 | Variable         | Default                 | Description            |
 | ---------------- | ----------------------- | ---------------------- |
 | MONGO_DATABASE   | short_url_db            | MongoDB database name  |
-| MONGN_SERVER_URL | mongodb://mongodb:27017 | MongoDB connection URL |
+| MONGO_SERVER_URL | mongodb://mongodb:27017 | MongoDB connection URL |
 
 #### OIDC Configuration
 | Variable       | Default          | Description                 |

--- a/src/shared/model/config.model.go
+++ b/src/shared/model/config.model.go
@@ -9,7 +9,7 @@ type OidcConfig struct {
 
 type MongoDdConfig struct {
 	Database       string `env:"MONGO_DATABASE, default=short_url_db"`
-	MongoServerUrl string `env:"MONGN_SERVER_URL, default=mongodb://mongodb:27017"`
+	MongoServerUrl string `env:"MONGO_SERVER_URL, default=mongodb://mongodb:27017"`
 }
 
 // BaseServerConfig contains common server configuration fields


### PR DESCRIPTION
## Summary
- fix typo in MongoDB URL env variable

## Testing
- `go test ./...` *(fails: directory prefix . does not contain modules)*

------
https://chatgpt.com/codex/tasks/task_e_68558ad75240832d87c21739ff011d9e