### PR TITLE
Fix Perso config docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Easily create and share memorable links to any webpage with bly.li! Simply input
 | ---------------- | ------- | -------------------------------- |
 | SERVER_PORT      | :8084   | HTTP server port                 |
 | METRICS_PORT     | :9084   | Prometheus metrics endpoint port |
-| CLEANUP_INTERVAL | 24h     | Interval for cleanup operations  |
+| CLEANUP_INTERVAL | 1m      | Interval for cleanup operations  |
 
 ### Project Structure
 


### PR DESCRIPTION
## Summary
- update Perso cleanup interval default in README

## Testing
- `go vet ./...` *(fails: directory prefix does not contain modules)*

------
https://chatgpt.com/codex/tasks/task_e_68558d4841ac832db3447740296b7345