### PR TITLE
Fix typo in logging error messages

### DIFF
--- a/src/shared/utils/logging/error.go
+++ b/src/shared/utils/logging/error.go
@@ -6,11 +6,11 @@ import (
 
 func LogMongoError(err error) {
 	if err != nil {
-		slog.Error("MongoDB-Error occured", "error", err)
+		slog.Error("MongoDB error occurred", "error", err)
 	}
 }
 func LogRedisError(err error) {
 	if err != nil {
-		slog.Error("Redis-Error occured", "error", err)
+		slog.Error("Redis error occurred", "error", err)
 	}
 }


### PR DESCRIPTION
## Summary
- fix typos in MongoDB and Redis error log messages

## Testing
- `go test ./src/shared/...`


------
https://chatgpt.com/codex/tasks/task_e_68558d542cf8832da3926900f2067f72