### PR TITLE
Add unit tests for API utils

### DIFF
--- a/src/shared/utils/api/oidc_test.go
+++ b/src/shared/utils/api/oidc_test.go
@@ -1,0 +1,27 @@
+package api
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func TestTokenFromHeader(t *testing.T) {
+	cases := []struct {
+		name   string
+		header string
+		want   string
+	}{
+		{"valid bearer", "Bearer token123", "token123"},
+		{"case insensitive", "bearer token456", "token456"},
+		{"malformed header", "Basic abc", ""},
+		{"too short", "Bearer", ""},
+	}
+
+	for _, tc := range cases {
+		req := httptest.NewRequest("GET", "http://example.com", nil)
+		req.Header.Set("Authorization", tc.header)
+		if got := TokenFromHeader(req); got != tc.want {
+			t.Errorf("%s: got %q want %q", tc.name, got, tc.want)
+		}
+	}
+}

--- a/src/shared/utils/api/utils_test.go
+++ b/src/shared/utils/api/utils_test.go
@@ -1,0 +1,34 @@
+package api
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func TestReadUserIPPrecedence(t *testing.T) {
+	cases := []struct {
+		name      string
+		real      string
+		forwarded string
+		remote    string
+		want      string
+	}{
+		{"real header preferred", "1.1.1.1", "2.2.2.2", "3.3.3.3", "1.1.1.1"},
+		{"forwarded header next", "", "2.2.2.2", "3.3.3.3", "2.2.2.2"},
+		{"remote addr fallback", "", "", "3.3.3.3", "3.3.3.3"},
+	}
+
+	for _, tc := range cases {
+		req := httptest.NewRequest("GET", "http://example.com", nil)
+		req.RemoteAddr = tc.remote
+		if tc.real != "" {
+			req.Header.Set("X-Real-Ip", tc.real)
+		}
+		if tc.forwarded != "" {
+			req.Header.Set("X-Forwarded-For", tc.forwarded)
+		}
+		if got := ReadUserIP(req); got != tc.want {
+			t.Errorf("%s: got %q want %q", tc.name, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add tests for `ReadUserIP` precedence
- add tests for `TokenFromHeader` parsing

## Testing
- `go test ./src/shared/utils/api ./src/shared/utils ./src/services/shortn/utils`

------
https://chatgpt.com/codex/tasks/task_e_685695d804d8832db299016bfb931aef