### PR TITLE
Refactor theme service to use signals

### DIFF
--- a/src/services/front/src/app/components/graphs/line-chart/line-chart.component.ts
+++ b/src/services/front/src/app/components/graphs/line-chart/line-chart.component.ts
@@ -135,9 +135,7 @@ export class LineChartComponent implements OnInit {
         palette: COLOR_PALET,
       },
     };
-  }
 
-  ngOnInit(): void {
     effect(() => {
       const theme =
         this.themeService.theme() === 'lite' ? 'light' : 'dark';
@@ -147,6 +145,9 @@ export class LineChartComponent implements OnInit {
       };
       this.chart?.updateOptions(this.chartOptions);
     });
+  }
+
+  ngOnInit(): void {
     // Resample at 1-hour intervals (3600000 ms)
     const tenMinMs = 10 * 60 * 1000;
     this.data$.subscribe((data) => {

--- a/src/services/front/src/app/components/graphs/line-chart/line-chart.component.ts
+++ b/src/services/front/src/app/components/graphs/line-chart/line-chart.component.ts
@@ -4,8 +4,6 @@ import {
   ViewChild,
   Input,
   OnInit,
-  AfterViewInit,
-  AfterContentInit,
   ChangeDetectionStrategy,
   effect,
 } from '@angular/core';
@@ -124,11 +122,10 @@ export class LineChartComponent implements OnInit {
           },
         },
       },
-      tooltip:{
-        x:{
-          format: "HH:mm dd.MM.yyyy"
-        }
-
+      tooltip: {
+        x: {
+          format: 'HH:mm dd.MM.yyyy',
+        },
       },
       markers: {},
       theme: {
@@ -137,8 +134,7 @@ export class LineChartComponent implements OnInit {
     };
 
     effect(() => {
-      const theme =
-        this.themeService.theme() === 'lite' ? 'light' : 'dark';
+      const theme = this.themeService.theme() === 'lite' ? 'light' : 'dark';
       this.chartOptions.theme = {
         mode: theme,
         palette: COLOR_PALET,

--- a/src/services/front/src/app/components/graphs/line-chart/line-chart.component.ts
+++ b/src/services/front/src/app/components/graphs/line-chart/line-chart.component.ts
@@ -7,6 +7,7 @@ import {
   AfterViewInit,
   AfterContentInit,
   ChangeDetectionStrategy,
+  effect,
 } from '@angular/core';
 import { resampleData } from '../../../utils/chart.utils';
 import {
@@ -22,7 +23,7 @@ import {
   NgApexchartsModule,
   ApexTheme,
 } from 'ng-apexcharts';
-import { map, Observable } from 'rxjs';
+import { Observable } from 'rxjs';
 import { ThemeService } from '../../../services/theme.service';
 
 export type ChartOptions = {
@@ -137,15 +138,15 @@ export class LineChartComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.themeService.theme$
-      .pipe(map((theme) => (theme === 'lite' ? 'light' : 'dark')))
-      .subscribe((theme) => {
-        this.chartOptions.theme = {
-          mode: theme,
-          palette: COLOR_PALET,
-        };
-        this.chart?.updateOptions(this.chartOptions);
-      });
+    effect(() => {
+      const theme =
+        this.themeService.theme() === 'lite' ? 'light' : 'dark';
+      this.chartOptions.theme = {
+        mode: theme,
+        palette: COLOR_PALET,
+      };
+      this.chart?.updateOptions(this.chartOptions);
+    });
     // Resample at 1-hour intervals (3600000 ms)
     const tenMinMs = 10 * 60 * 1000;
     this.data$.subscribe((data) => {

--- a/src/services/front/src/app/components/theme-toggle/theme-toggle.component.ts
+++ b/src/services/front/src/app/components/theme-toggle/theme-toggle.component.ts
@@ -20,27 +20,26 @@ const MODES: ThemeMode[] = ['system', 'lite', 'dark'];
   `,
 })
 export class ThemeToggleComponent {
-  mode: ThemeMode = 'system';
-
-  constructor(private readonly themeService: ThemeService) {
-    this.themeService.mode$.subscribe((m) => (this.mode = m));
-  }
+  constructor(private readonly themeService: ThemeService) {}
 
   cycleMode() {
-    const idx = MODES.indexOf(this.mode);
+    const current = this.themeService.mode();
+    const idx = MODES.indexOf(current);
     const nextMode = MODES[(idx + 1) % MODES.length];
     this.themeService.setMode(nextMode);
   }
 
   get modeLabel() {
-    if (this.mode === 'system') return 'System';
-    if (this.mode === 'lite') return 'Light';
+    const mode = this.themeService.mode();
+    if (mode === 'system') return 'System';
+    if (mode === 'lite') return 'Light';
     return 'Dark';
   }
 
   get modeClass() {
-    if (this.mode === 'system') return 'fa-regular fa-compass';
-    if (this.mode === 'lite') return 'fa-regular fa-sun';
+    const mode = this.themeService.mode();
+    if (mode === 'system') return 'fa-regular fa-compass';
+    if (mode === 'lite') return 'fa-regular fa-sun';
     return 'fa-regular fa-moon';
   }
 }

--- a/src/services/front/src/app/services/theme.service.ts
+++ b/src/services/front/src/app/services/theme.service.ts
@@ -1,7 +1,13 @@
 // src/app/services/theme.service.ts
 
-import { Injectable } from '@angular/core';
-import { BehaviorSubject, map, Observable } from 'rxjs';
+import {
+  Injectable,
+  computed,
+  effect,
+  signal,
+} from '@angular/core';
+import { toObservable } from '@angular/core/rxjs-interop';
+import { Observable } from 'rxjs';
 
 export type ThemeMode = 'lite' | 'dark' | 'system';
 
@@ -9,34 +15,35 @@ export type ThemeMode = 'lite' | 'dark' | 'system';
   providedIn: 'root',
 })
 export class ThemeService {
-  private readonly modeSubject = new BehaviorSubject<ThemeMode>(
-    this.loadMode()
-  );
-  public mode$ = this.modeSubject.asObservable();
+  /** Current theme mode */
+  readonly mode = signal<ThemeMode>(this.loadMode());
+  /** Observable view of the current mode for legacy consumers */
+  readonly mode$: Observable<ThemeMode> = toObservable(this.mode);
 
-  public theme$: Observable<'dark' | 'lite'> = this.modeSubject.pipe(
-    map((a) => {
-      if (a !== 'system') return a;
-      return window.matchMedia('(prefers-color-scheme: dark)').matches
-        ? 'dark'
-        : 'lite';
-    })
-  );
+  /** Derived signal representing the active theme */
+  readonly theme = computed<'dark' | 'lite'>(() => {
+    const m = this.mode();
+    if (m !== 'system') return m;
+    return window.matchMedia('(prefers-color-scheme: dark)').matches
+      ? 'dark'
+      : 'lite';
+  });
+  /** Observable view of the current theme for legacy consumers */
+  readonly theme$: Observable<'dark' | 'lite'> = toObservable(this.theme);
 
   constructor() {
-    this.applyTheme(this.modeSubject.value);
+    effect(() => this.applyTheme(this.mode()));
 
     window
       .matchMedia('(prefers-color-scheme: dark)')
       .addEventListener('change', () => {
-        if (this.modeSubject.value === 'system') this.applyTheme('system');
+        if (this.mode() === 'system') this.applyTheme('system');
       });
   }
 
   setMode(mode: ThemeMode) {
-    this.modeSubject.next(mode);
+    this.mode.set(mode);
     this.saveMode(mode);
-    this.applyTheme(mode);
   }
 
   private applyTheme(mode: ThemeMode) {

--- a/src/services/front/src/app/services/theme.service.ts
+++ b/src/services/front/src/app/services/theme.service.ts
@@ -22,7 +22,6 @@ export class ThemeService {
 
   constructor() {
     effect(() => this.applyTheme(this.mode()));
-
     window
       .matchMedia('(prefers-color-scheme: dark)')
       .addEventListener('change', () => {

--- a/src/services/front/src/app/services/theme.service.ts
+++ b/src/services/front/src/app/services/theme.service.ts
@@ -1,13 +1,6 @@
 // src/app/services/theme.service.ts
 
-import {
-  Injectable,
-  computed,
-  effect,
-  signal,
-} from '@angular/core';
-import { toObservable } from '@angular/core/rxjs-interop';
-import { Observable } from 'rxjs';
+import { Injectable, computed, effect, signal } from '@angular/core';
 
 export type ThemeMode = 'lite' | 'dark' | 'system';
 
@@ -17,8 +10,6 @@ export type ThemeMode = 'lite' | 'dark' | 'system';
 export class ThemeService {
   /** Current theme mode */
   readonly mode = signal<ThemeMode>(this.loadMode());
-  /** Observable view of the current mode for legacy consumers */
-  readonly mode$: Observable<ThemeMode> = toObservable(this.mode);
 
   /** Derived signal representing the active theme */
   readonly theme = computed<'dark' | 'lite'>(() => {
@@ -28,8 +19,6 @@ export class ThemeService {
       ? 'dark'
       : 'lite';
   });
-  /** Observable view of the current theme for legacy consumers */
-  readonly theme$: Observable<'dark' | 'lite'> = toObservable(this.theme);
 
   constructor() {
     effect(() => this.applyTheme(this.mode()));


### PR DESCRIPTION
## Summary
- use Angular signals in `ThemeService`
- auto-apply theme via an effect when mode changes

## Testing
- `npm test` *(fails: ng not found)*
- `go test ./...` *(fails: directory prefix . does not contain modules)*

------
https://chatgpt.com/codex/tasks/task_e_68596cfd944c832dac8ff208737ce61d